### PR TITLE
Fix encryption pop-up to also appear when user have one location

### DIFF
--- a/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
@@ -45,10 +45,6 @@ export const ChooseLocation: React.FC<ChooseLocationProps> = ({
         : Promise.resolve();
 
       sessionDefined.then(() => {
-        if (isPasswordExpired && isPasswordExpired()) {
-          openModal("offline-encryption-online-dialog");
-          return;
-        }
         if (
           referrer &&
           !["/", "/login", "/login/location"].includes(referrer)
@@ -64,8 +60,14 @@ export const ChooseLocation: React.FC<ChooseLocationProps> = ({
         return;
       });
     },
-    [referrer, config.links.loginSuccess, returnToUrl, openModal]
+    [referrer, config.links.loginSuccess, returnToUrl]
   );
+
+  useEffect(() => {
+    if (isPasswordExpired && isPasswordExpired()) {
+      openModal("offline-encryption-online-dialog");
+    }
+  }, [openModal]);
 
   // Handle cases where the location picker is disabled, there is only one
   // location, or there are no locations.


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fix encryption pop-up to also appear when user have one location
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
